### PR TITLE
Add "heroku" in build command line to enable easy profile activation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,7 @@ cd $BUILD_DIR
 export MAVEN_OPTS="-Xmx512m"
 
 # build app
-BUILDCMD="$CACHE_DIR/.maven/bin/mvn -B -Duser.home=$BUILD_DIR -Dmaven.repo.local=$CACHE_DIR/.m2/repository -s $CACHE_DIR/.m2/settings.xml -DskipTests=true clean install"
+BUILDCMD="$CACHE_DIR/.maven/bin/mvn -B -Duser.home=$BUILD_DIR -Dmaven.repo.local=$CACHE_DIR/.m2/repository -s $CACHE_DIR/.m2/settings.xml -DskipTests=true -Dheroku clean install"
 echo "-----> executing $BUILDCMD"
 
 $BUILDCMD 2>&1 | sed -u 's/^/       /'


### PR DESCRIPTION
I just added -Dheroku to the maven command line to enable easy detection of heroku running the build command.

This allows build to detect wether the build is run through heroku or not, with conditional profile activation like this :

```
<profiles>
    <profile>
        <id>heroku</id>
        <activation>
            <property>
                <name>heroku</name>
            </property>
        </activation>
       ...
    </profile>
</profiles>
```

Each & every application pom.xml will run with no changes, but some who wants to benefit from it, can, where before we should rely on ugly hacks (like file detection) to know wether or not the build is run through heroku.
This is useful since it speed up the build process when run outside of heroku, (most of the time the local copy dependencies is not useful during a non-heroku build, which is probably more common).

full runnning example to test the build pack :

heroku create --stack cedar --buildpack http://github.com/jeanlaurent/heroku-buildpack-java.git
with a pom.xml slighty changed from the heroku java tutorial to (we just wrapped the maven dep copy within a profile) : 

```
<profiles>
    <profile>
        <id>heroku</id>
        <activation>
            <property>
                <name>heroku</name>
            </property>
        </activation>
        <build>
            <plugins>
                <plugin>
                    <artifactId>maven-dependency-plugin</artifactId>
                    <executions>
                        <execution>
                            <id>copy-dependencies</id>
                            <phase>package</phase>
                            <goals>
                                <goal>copy-dependencies</goal>
                            </goals>
                            <configuration>
                                <stripVersion>true</stripVersion>
                                <includeScope>compile</includeScope>
                                <includeScope>runtime</includeScope>
                                <excludeScope>test</excludeScope>
                                <outputDirectory>${project.build.directory}/lib</outputDirectory>
                            </configuration>
                        </execution>
                    </executions>
                </plugin>
            </plugins>
        </build>
    </profile>
</profiles>
```

running mvn clean install outside heroku is speedy as the copy dep is skipped, and it still is activated when run from heroku.
