### PR TITLE
Overlay JDK

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -51,6 +51,7 @@ if [ -f ${BUILD_DIR}/system.properties ]; then
   javaVersion=$(detect_java_version ${BUILD_DIR})
   echo -n "-----> Installing OpenJDK ${javaVersion}..."
   install_java ${BUILD_DIR} ${javaVersion}
+  jdk_overlay ${BUILD_DIR}
   echo "done"
   cp ${BUILD_DIR}/system.properties ${CACHE_DIR}/
 fi


### PR DESCRIPTION
Allows users to overly the jdk. Copies .jdk-overlay into .jdk. This allows for things like copying jce files in from their git repository.

See also heroku/heroku-buildpack-jvm-common#5

Note: this is tested in jvm-common.
