### PR TITLE
Allowing for --update-snapshots to be optionally defined

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -70,7 +70,7 @@ cd $BUILD_DIR
 export MAVEN_OPTS="-Xmx512m"
 
 # build app
-BUILDCMD="$CACHE_DIR/.maven/bin/mvn -B ${UPDATE_SNAPSHOTS:+--update-snapshots} -Duser.home=$BUILD_DIR -Dmaven.repo.local=$CACHE_DIR/.m2/repository -s $CACHE_DIR/.m2/settings.xml -DskipTests=true clean install"
+BUILDCMD="$CACHE_DIR/.maven/bin/mvn -B ${UPDATE_SNAPSHOTS:+--update-snapshots} -Duser.home=$BUILD_DIR -Dmaven.repo.local=$CACHE_DIR/.m2/repository -s $CACHE_DIR/.m2/settings.xml -DskipTests=true ${MVN_PROFILE:+-P$MVN_PROFILE} clean install"
 echo "-----> executing $BUILDCMD"
 
 $BUILDCMD 2>&1 | sed -u 's/^/       /'


### PR DESCRIPTION
During development of a multiple pom project, sometimes its useful to tell maven to update the snapshots instead of  having to clear the M2 repository cache and having it have to redownload all of the other dependencies. This change allows the developer to do set an environmental variable for the app to tell it to have maven update the snapshot dependencies of a project. 
