### PR TITLE
update default heroku postgresql database

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -10,5 +10,5 @@ config_vars:
   JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
   MAVEN_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops 
 addons:
-  heroku-postgresql:dev
+  heroku-postgresql:hobby-dev
 EOF


### PR DESCRIPTION
With [Heroku Postgres 2.0](https://postgres.heroku.com/blog/past/2013/11/11/heroku_postgres_20/), the free plan is now called `Hobby Dev`.
