### PR TITLE
Adding logic to skip Maven if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ $ heroku config:set MAVEN_JAVA_OPTS="-Xss2g"
 
 Other options are available for [defining a custom `settings.xml` file](https://devcenter.heroku.com/articles/using-a-custom-maven-settings-xml).
 
+### Install Java Only
+
+Useful when you already have a built artifact, and you only need Java to launch it in an embedded server.
+
++ `JAVA_ONLY`: not set by default
+
 ## Development
 
 To make changes to this buildpack, fork it on Github. Push up changes to your fork, then create a new Heroku app to test it, or configure an existing app to use your buildpack:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Useful when you already have a built artifact, and you only need Java to launch 
 
 + `JAVA_ONLY`: not set by default
 
+The variable must be set to `true` to skip running Maven:
+
+```sh-session
+$ heroku config:set JAVA_ONLY="true"
+```
+
 ## Development
 
 To make changes to this buildpack, fork it on Github. Push up changes to your fork, then create a new Heroku app to test it, or configure an existing app to use your buildpack:

--- a/bin/compile
+++ b/bin/compile
@@ -27,43 +27,47 @@ install_java ${BUILD_DIR} ${javaVersion}
 jdk_overlay ${BUILD_DIR}
 status_done
 
-#create the cache dir if it doesn't exist
-mkdir -p $CACHE_DIR
+# Skip Maven only if set to true
+if [ ! "$JAVA_ONLY" = true ]; then
 
-# change to cache dir to install maven
-cd $CACHE_DIR
-install_maven ${CACHE_DIR} ${BUILD_DIR}
-
-if [ -n "$MAVEN_SETTINGS_PATH" ]; then
-  MAVEN_SETTINGS_OPT="-s $MAVEN_SETTINGS_PATH"
-elif [ -n "$MAVEN_SETTINGS_URL" ]; then
-  status_pending "Installing settings.xml"
-  mkdir -p .m2
-  curl --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output .m2/settings.xml
-  status_done
-  MAVEN_SETTINGS_OPT="-s $CACHE_DIR/.m2/settings.xml"
-elif [ -f $BUILD_DIR/settings.xml ]; then
-  MAVEN_SETTINGS_OPT="-s $BUILD_DIR/settings.xml"
-else
-  unset MAVEN_SETTINGS_OPT
-fi
-
-# change to build dir to run maven
-cd $BUILD_DIR
-
-export MAVEN_OPTS="-Xmx1024m ${MAVEN_JAVA_OPTS} -Duser.home=$BUILD_DIR -Dmaven.repo.local=$CACHE_DIR/.m2/repository"
-
-# build app
-mvnOpts="-B"
-mvnOpts="${mvnOpts}${MAVEN_SETTINGS_OPT:+ $MAVEN_SETTINGS_OPT}"
-mvnOpts="${mvnOpts} ${MAVEN_CUSTOM_OPTS:-"-DskipTests=true"}"
-mvnOpts="${mvnOpts} ${MAVEN_CUSTOM_GOALS:-"clean install"}"
-
-status "Executing: mvn ${mvnOpts}"
-$CACHE_DIR/.maven/bin/mvn ${mvnOpts} | indent
-
-if [ "${PIPESTATUS[*]}" != "0 0" ]; then
-  error "Failed to build app with Maven
-We're sorry this build is failing! If you can't find the issue in application code,
-please submit a ticket so we can help: https://help.heroku.com/"
+  #create the cache dir if it doesn't exist
+  mkdir -p $CACHE_DIR
+  
+  # change to cache dir to install maven
+  cd $CACHE_DIR
+  install_maven ${CACHE_DIR} ${BUILD_DIR}
+  
+  if [ -n "$MAVEN_SETTINGS_PATH" ]; then
+    MAVEN_SETTINGS_OPT="-s $MAVEN_SETTINGS_PATH"
+  elif [ -n "$MAVEN_SETTINGS_URL" ]; then
+    status_pending "Installing settings.xml"
+    mkdir -p .m2
+    curl --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output .m2/settings.xml
+    status_done
+    MAVEN_SETTINGS_OPT="-s $CACHE_DIR/.m2/settings.xml"
+  elif [ -f $BUILD_DIR/settings.xml ]; then
+    MAVEN_SETTINGS_OPT="-s $BUILD_DIR/settings.xml"
+  else
+    unset MAVEN_SETTINGS_OPT
+  fi
+  
+  # change to build dir to run maven
+  cd $BUILD_DIR
+  
+  export MAVEN_OPTS="-Xmx1024m ${MAVEN_JAVA_OPTS} -Duser.home=$BUILD_DIR -Dmaven.repo.local=$CACHE_DIR/.m2/repository"
+  
+  # build app
+  mvnOpts="-B"
+  mvnOpts="${mvnOpts}${MAVEN_SETTINGS_OPT:+ $MAVEN_SETTINGS_OPT}"
+  mvnOpts="${mvnOpts} ${MAVEN_CUSTOM_OPTS:-"-DskipTests=true"}"
+  mvnOpts="${mvnOpts} ${MAVEN_CUSTOM_GOALS:-"clean install"}"
+  
+  status "Executing: mvn ${mvnOpts}"
+  $CACHE_DIR/.maven/bin/mvn ${mvnOpts} | indent
+  
+  if [ "${PIPESTATUS[*]}" != "0 0" ]; then
+    error "Failed to build app with Maven
+  We're sorry this build is failing! If you can't find the issue in application code,
+  please submit a ticket so we can help: https://help.heroku.com/"
+  fi
 fi


### PR DESCRIPTION
Through the use of the `JAVA_ONLY` variable, users are now able to choose in install both Java and Maven to complete a full build, or only install Java. This can be useful if the user already has a built artifact they wish to deploy via embedded Jetty or Tomcat server.