### PR TITLE
Changing to not hard add-on code plan

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -8,5 +8,5 @@ cat <<EOF
 config_vars:
   JAVA_OPTS: -XX:+UseCompressedOops
 addons:
-  heroku-postgresql:hobby-dev
+  heroku-postgresql
 EOF


### PR DESCRIPTION
This will allow the lowest available plan to be selected  by default as opposed to the hard coded one today.