### PR TITLE
Use export_env function correctly

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh
 source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
 
-export_env "JAVA_OPTS|JAVA_TOOL_OPTIONS"
+export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 
 install_jdk ${BUILD_DIR}
 

--- a/bin/test
+++ b/bin/test
@@ -12,7 +12,7 @@ source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh
 source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
 
-export_env
+export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 
 cd $BUILD_DIR
 

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -15,7 +15,7 @@ source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh
 source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
 
-export_env "JAVA_OPTS|JAVA_TOOL_OPTIONS"
+export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 
 install_jdk ${BUILD_DIR}
 


### PR DESCRIPTION
The earlier use was incorrect, and resulted in nothing being exported. I'm surprised it didn't error out though.