### PR TITLE
Added a stderr message when bin/detect fails

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -9,7 +9,9 @@ if [ -f $1/pom.xml ] ||
    [ -f $1/pom.scala ] ||
    [ -f $1/pom.yaml ] ||
    [ -f $1/pom.yml ] ; then
-  echo "Java" && exit 0
+  echo "Java"
+  exit 0
 else
-  echo "no" && exit 1
+  (>&2 echo "Could not find a pom.xml file! Please check that it exists and is committed to Git.")
+  exit 1
 fi

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -79,7 +79,7 @@ testNoDetectMissingPomFile()
 {
   detect
 
-  assertNoAppDetected
+  assertEquals "1" "${RETURN}"
 }
 
 testNoDetectPomFileAsDir()
@@ -88,5 +88,5 @@ testNoDetectPomFileAsDir()
 
   detect
 
-  assertNoAppDetected
+  assertEquals "1" "${RETURN}"
 }


### PR DESCRIPTION
It will look like this:

```
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> App not compatible with buildpack: heroku/java
remote:        Could not find a pom.xml file! Please check that it exists and is committed to Git.
remote:
remote:        More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !       Push rejected to jkutner-test.
remote:
```