### PR TITLE
Fix some Bash issues

### DIFF
--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -40,4 +40,4 @@ export HATCHET_APP_LIMIT=20
 export HATCHET_DEPLOY_STRATEGY=git
 export HATCHET_BUILDPACK_BASE="https://github.com/heroku/$BUILDPACK_NAME"
 
-bundle exec rspec $@
+bundle exec rspec "$@"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -81,7 +81,7 @@ cache_copy() {
   rel_dir=$1
   from_dir=$2
   to_dir=$3
-  rm -rf $to_dir/$rel_dir
+  rm -rf "${to_dir:?}/${rel_dir:?}"
   if [ -d $from_dir/$rel_dir ]; then
     mkdir -p $to_dir/$rel_dir
     cp -pr $from_dir/$rel_dir/. $to_dir/$rel_dir


### PR DESCRIPTION
Double quote array expansions, otherwise they're like `$*` and break on spaces.
Use `"${var:?}"` to ensure this never expands to `/` .