### PR TITLE
 Don't hardcode $BUILD_DIR in maven profile

### DIFF
--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -115,11 +115,10 @@ please submit a ticket so we can help: https://help.heroku.com/"
 
 write_mvn_profile() {
   local home=${1}
-  local mvnBinDir=${home}/.maven/bin
   mkdir -p ${home}/.profile.d
   cat << EOF > ${home}/.profile.d/maven.sh
-export M2_HOME="${home}/.maven"
-export MAVEN_OPTS="$(_mvn_java_opts "test" ${home} ${home})"
-export PATH="${mvnBinDir}:\$PATH"
+export M2_HOME="\$HOME/.maven"
+export MAVEN_OPTS="$(_mvn_java_opts "test" "\$HOME" "\$HOME")"
+export PATH="\$M2_HOME/bin:\$PATH"
 EOF
 }

--- a/test/test_test.sh
+++ b/test/test_test.sh
@@ -5,7 +5,7 @@
 
 capture_test()
 {
-  . $BUILD_DIR/.profile.d/maven.sh
+  HOME=$BUILD_DIR . $BUILD_DIR/.profile.d/maven.sh
   capture ${BUILDPACK_HOME}/bin/test ${BUILD_DIR} ${ENV_DIR}
 }
 


### PR DESCRIPTION
`/bin/test-compile` is hardcoding `$BUILD_DIR` into `$HOME/.profile.d/maven.sh`

This patch will potspone use `$HOME` instead.
