### PR TITLE
/bin/test has only 2 parameters

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ set -e
 
 BP_DIR=$(cd $(dirname $0)/..; pwd) # absolute path
 BUILD_DIR=$1
-ENV_DIR=$3
+ENV_DIR=$2
 
 source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh

--- a/test/test_test.sh
+++ b/test/test_test.sh
@@ -6,7 +6,7 @@
 capture_test()
 {
   . $BUILD_DIR/.profile.d/maven.sh
-  capture ${BUILDPACK_HOME}/bin/test ${BUILD_DIR} ${CACHE_DIR} ${ENV_DIR}
+  capture ${BUILDPACK_HOME}/bin/test ${BUILD_DIR} ${ENV_DIR}
 }
 
 capture_test_compile()


### PR DESCRIPTION
According to https://devcenter.heroku.com/articles/testpack-api the right signature is `/bin/test BUILD_DIR ENV_DIR`