### PR TITLE
Cache JVM Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
++ Cache system.properties file
+
+## 63
+
 + Add support for MAVEN_HEROKU_CI_GOAL
 
 ## 62

--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
 
 export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 
-install_jdk ${BUILD_DIR}
+install_jdk "${BUILD_DIR}" "${CACHE_DIR}"
 
 [ -n "$(find ${BUILD_DIR} -type f -name "*.kt")" ] && mcount "kotlin.source"
 [ -n "$(find ${BUILD_DIR} -type f -name "*.groovy")" ] && mcount "groovy.source"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -90,6 +90,7 @@ cache_copy() {
 
 install_jdk() {
   local install_dir=${1}
+  local cache_dir=${2}
 
   let start=$(nowms)
   JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz}
@@ -101,6 +102,6 @@ install_jdk() {
   mtime "jvm-common.install.time" "${start}"
 
   let start=$(nowms)
-  install_java_with_overlay ${install_dir}
+  install_java_with_overlay "${install_dir}" "${cache_dir}"
   mtime "jvm.install.time" "${start}"
 }

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -140,6 +140,7 @@ testCompileWithoutSystemProperties() {
   assertCaptured "Installing JDK 1.8"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
+  assertTrue "system.properties was not cached" "[ -f $CACHE_DIR/system.properties ]"
 }
 
 testCompile()
@@ -151,6 +152,8 @@ testCompile()
   assertCapturedSuccess
 
   _assertMavenLatest
+  assertTrue "system.properties was not cached" "[ -f $CACHE_DIR/system.properties ]"
+  assertContains "system.properties contains the wrong version" "java.runtime.version=1.8" "$(cat $CACHE_DIR/system.properties)"
 }
 
 testCompilationFailure()
@@ -167,8 +170,8 @@ testNewAppsRemoveM2Cache()
 {
   createPom
   rm -r ${CACHE_DIR} # simulate a brand new app without a cache dir
-
   assertFalse "Precondition: New apps should not have a CACHE_DIR prior to running" "[ -d ${CACHE_DIR} ]"
+  mkdir ${CACHE_DIR}
 
   compile
 


### PR DESCRIPTION
Pass cache_dir to jvm buildpack so that `system.properties` file can be cached

See https://github.com/heroku/heroku-buildpack-jvm-common/pull/82