### PR TITLE
maven requires JAVA_HOME being set

### DIFF
--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -82,6 +82,9 @@ run_mvn() {
   local home=${2}
   local mavenInstallDir=${3}
 
+  export JAVA_HOME=${home}/.jdk
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+
   mkdir -p ${mavenInstallDir}
   if has_maven_wrapper $home; then
     cache_copy ".m2/wrapper" $mavenInstallDir $home


### PR DESCRIPTION
@jkutner I ran into this when attempting to run this buildpack within https://github.com/heroku/stack-images/tree/master/heroku-18-build

I noticed the cloud native buildpack had a note about something similar: https://github.com/heroku/java-buildpack/blob/58b1b157d0322da10981ecf6abe11069896cfd06/bin/build#L37-L39

Think this the right place for the fix? Saw that the `heroku/jvm-common` buildpack sets it in https://github.com/heroku/heroku-buildpack-jvm-common/blob/4d7c3f40d352d5a5090091d026017da18c2ede28/bin/java#L70-L71 in order to install the jdk, but it is also needed for maven execution here in `heroku/java`.

## steps to reproduce

With a `bin/test-compile` in `$PWD` for an example java application that looks like the following:
```
buildDir=$1
cacheDir=$2
envDir=$3

tmpdir=$(mktemp -d)

curl --silent --location https://github.com/heroku/heroku-buildpack-java/archive/master.tar.gz | tar xzm -C $tmpdir --strip-components=1

${tmpdir}/bin/test-compile $1 $2 $3
```

Running `bin/test-compile` within `heroku/heroku:18-build` while having `$PWD` mounted to `/app` results in:
```
$ docker run --rm -v $PWD:/app heroku/heroku:18-build /bin/bash -c "/app/bin/test-compile /app /app"
-----> Using provided JDK
-----> Executing: ./mvnw clean dependency:resolve-plugins test-compile
Error: JAVA_HOME is not defined correctly.
  We cannot execute 

 !     ERROR: Failed to build app with Maven
       We're sorry this build is failing! If you can't find the issue in application code,
       please submit a ticket so we can help: https://help.heroku.com/
```

## after fix
```
$ docker run --rm -v $PWD:/app heroku/heroku:18-build /bin/bash -c "/app/bin/test-compile /app /app"
-----> Using provided JDK
-----> Executing: ./mvnw clean dependency:resolve-plugins test-compile
       [INFO] Scanning for projects...
       [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.1.2.RELEASE/spring-boot-starter-parent-2.1.2.RELEASE.pom
...
       [INFO] BUILD SUCCESS
       [INFO] ------------------------------------------------------------------------
       [INFO] Total time:  02:05 min
       [INFO] Finished at: 2019-05-01T23:10:52Z
       [INFO] ------------------------------------------------------------------------
```
