### PR TITLE
Remove check for .mvn/wrapper/maven-wrapper.jar 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
++ Add support for Maven wrapper without binary JAR by removing check for .mvn/wrapper/maven-wrapper.jar
+
+## v65
+
 + Upgrade default Maven version to 3.6.2
 
 ## 64

--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -59,7 +59,6 @@ _mvn_settings_opt() {
 has_maven_wrapper() {
   local home=${1}
   if [ -f $home/mvnw ] &&
-      [ -f $home/.mvn/wrapper/maven-wrapper.jar ] &&
       [ -f $home/.mvn/wrapper/maven-wrapper.properties ] &&
       [ -z "$(detect_maven_version $home)" ]; then
     return 0;


### PR DESCRIPTION
This change enables support for using the [Maven wrapper without a binary JAR](https://github.com/takari/maven-wrapper#usage-without-binary-jar).

Fixes #121