### PR TITLE
Add io.buildpacks.stacks.bionic as supported stack [changelog skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 + Add support for Cloud Native Buildpacks API
 + Add support for Maven wrapper without binary JAR by removing check for .mvn/wrapper/maven-wrapper.jar
++ Add io.buildpacks.stacks.bionic as supported stack
 
 ## v65
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 + Add support for Cloud Native Buildpacks API
 + Add support for Maven wrapper without binary JAR by removing check for .mvn/wrapper/maven-wrapper.jar
-+ Add io.buildpacks.stacks.bionic as supported stack
 
 ## v65
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -26,3 +26,6 @@ name = "Java"
 
 [[stacks]]
 id = "heroku-18"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,5 +27,6 @@ name = "Java"
 [[stacks]]
 id = "heroku-18"
 
+# this is to allow testing of other stack compatibility and is not a guarantee
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
[This RFC](https://github.com/buildpacks/rfcs/pull/40) is working its way through and it seems useful to be able to use Heroku buildpacks on `cloudfoundry/cnb:bionic`. This also aligns with how riff is compatible with [multiple stacks](https://github.com/projectriff/node-function-buildpack/blob/master/buildpack.toml#L22).