### PR TITLE
[changelog skip] Hatchet v7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   global:
   - IS_RUNNING_ON_TRAVIS=true
   - SHUNIT_HOME="/tmp/shunit2-2.1.6"
+  - HATCHET_EXPENSIVE_MODE=1
+
   matrix:
   - HEROKU_TEST_STACK="heroku-16"
   - HEROKU_TEST_STACK="heroku-18"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'heroku_hatchet', '~> 4.0', '>= 4.0.9'
+gem 'heroku_hatchet'
 gem 'rspec-retry'
 gem 'rspec-expectations'
 gem "parallel_tests"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.73.0)
-    heroics (0.0.25)
+    excon (0.76.0)
+    heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (4.1.2)
+    heroku_hatchet (7.0.0)
       excon (~> 0)
-      minitest-retry (~> 0.1.9)
-      platform-api (~> 2)
-      repl_runner (~> 0.0.3)
+      platform-api (~> 3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.8.2)
-      concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
-    minitest-retry (0.1.9)
-      minitest (>= 5.0)
     moneta (1.0.0)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     parallel (1.17.0)
     parallel_tests (2.29.0)
       parallel
-    platform-api (2.2.0)
-      heroics (~> 0.0.25)
+    platform-api (3.0.0)
+      heroics (~> 0.1.1)
       moneta (~> 1.0.0)
-    repl_runner (0.0.3)
-      activesupport
+      rate_throttle_client (~> 0.1.0)
+    rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
@@ -48,16 +35,13 @@ GEM
       rspec-core (> 3.3)
     rspec-support (3.8.0)
     thor (0.20.3)
-    thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  heroku_hatchet (~> 4.0, >= 4.0.9)
+  heroku_hatchet
   parallel_tests
   rspec-expectations
   rspec-retry

--- a/spec/java_spec.rb
+++ b/spec/java_spec.rb
@@ -49,7 +49,7 @@ describe "Java" do
 
             expect(successful_body(app)).to eq("/1")
 
-            expect(app.run('echo \$JAVA_OPTS')).
+            expect(app.run('echo $JAVA_OPTS')).
                 to include(%q{-Xmx300m -Xss512k})
 
             expect(app.run("env", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"

--- a/spec/java_spec.rb
+++ b/spec/java_spec.rb
@@ -40,7 +40,7 @@ describe "Java" do
 
   context "korvan" do
     ["1.8", "9", "10", "11"].each do |version|
-      let(:app) { Hatchet::Runner.new("korvan") }
+      let(:app) { Hatchet::Runner.new("korvan", run_multi: true) }
       context "on jdk-#{version}" do
         let(:jdk_version) { version }
         it "runs commands" do
@@ -52,21 +52,17 @@ describe "Java" do
             expect(app.run('echo \$JAVA_OPTS')).
                 to include(%q{-Xmx300m -Xss512k})
 
-            sleep 1
             expect(app.run("env", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                not_to include(%q{DATABASE_URL})
 
-            sleep 1 # make sure the dynos don't overlap
             expect(app.run("jce", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                 to include(%q{Encrypting, "Test"}).
                 and include(%q{Decrypted: Test})
 
-            sleep 1 # make sure the dynos don't overlap
             expect(app.run("netpatch", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                 to include(%q{name:eth0 (eth0)}).
                 and include(%q{name:lo (lo)})
 
-            sleep 1 # make sure the dynos don't overlap
             expect(app.run("https", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                 to include("Successfully invoked HTTPS service.").
                 and match(%r{"X-Forwarded-Proto(col)?":\s?"https"})
@@ -74,7 +70,6 @@ describe "Java" do
             # JDK 9, 10, and 11 do not have the jre/lib/ext dir where we drop
             # the pgconfig.jar
             if !jdk_version.match(/^9/) and !jdk_version.match(/^10/) and !jdk_version.match(/^11/)
-              sleep 1 # make sure the dynos don't overlap
               expect(app.run("pgssl", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                   to include("sslmode: require")
             end

--- a/spec/java_spec.rb
+++ b/spec/java_spec.rb
@@ -31,7 +31,7 @@ describe "Java" do
 
           expect(successful_body(app)).to eq("Hello from Java!")
 
-          expect(app.run("env", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
+          expect(app.run("env", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
               to include(%q{DATABASE_URL})
         end
       end
@@ -53,21 +53,21 @@ describe "Java" do
                 to include(%q{-Xmx300m -Xss512k})
 
             sleep 1
-            expect(app.run("env", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
+            expect(app.run("env", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                not_to include(%q{DATABASE_URL})
 
             sleep 1 # make sure the dynos don't overlap
-            expect(app.run("jce", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
+            expect(app.run("jce", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                 to include(%q{Encrypting, "Test"}).
                 and include(%q{Decrypted: Test})
 
             sleep 1 # make sure the dynos don't overlap
-            expect(app.run("netpatch", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
+            expect(app.run("netpatch", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                 to include(%q{name:eth0 (eth0)}).
                 and include(%q{name:lo (lo)})
 
             sleep 1 # make sure the dynos don't overlap
-            expect(app.run("https", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
+            expect(app.run("https", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                 to include("Successfully invoked HTTPS service.").
                 and match(%r{"X-Forwarded-Proto(col)?":\s?"https"})
 
@@ -75,7 +75,7 @@ describe "Java" do
             # the pgconfig.jar
             if !jdk_version.match(/^9/) and !jdk_version.match(/^10/) and !jdk_version.match(/^11/)
               sleep 1 # make sure the dynos don't overlap
-              expect(app.run("pgssl", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
+              expect(app.run("pgssl", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption }})). # work around a CLI bug that doesn't allow --exit-code when invoking a process type via "heroku run"
                   to include("sslmode: require")
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,10 +64,3 @@ def set_java_and_maven_versions(java_version, maven_version)
   `git add system.properties`
   `git commit -m "setting jdk and maven versions"`
 end
-
-ReplRunner.register_commands(:console)  do |config|
-  config.terminate_command "exit"          # the command you use to end the 'rails console'
-  config.startup_timeout 60                # seconds to boot
-  config.return_char "\n"                  # the character that submits the command
-  config.sync_stdout "STDOUT.sync = true"  # force REPL to not buffer standard out
-end


### PR DESCRIPTION
- ActiveSupport's Object#blank? and Object#present? are no longer provided by default (https://github.com/heroku/hatchet/pull/107)
- Remove deprecated support for passing a block to `App#run` (https://github.com/heroku/hatchet/pull/105)
- Ignore  403 on app delete due to race condition (https://github.com/heroku/hatchet/pull/101)
- The hatchet.lock file can now be locked to "main" in addition to "master" (https://github.com/heroku/hatchet/pull/86)
- Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps (https://github.com/heroku/hatchet/pull/94)
- Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
- Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)
- The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)
- App#deploy without a block will no longer run `teardown!` automatically (https://github.com/heroku/hatchet/pull/97)
- Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
- Calls to `app.run` are now rate throttled (https://github.com/heroku/hatchet/pull/99)
- Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)