### PR TITLE
v67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Java Buildpack Changelog
 
+## main
+
 ## v67
 
 + Update tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Java Buildpack Changelog
 
-## main
+## v67
+
++ Update tests
+
+## v66
 
 + Add support for Cloud Native Buildpacks API
 + Add support for Maven wrapper without binary JAR by removing check for .mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
In addition, add the correct header for previous `v66` release.