### PR TITLE
Add heroku-20 stack to CNB buildpack.toml [skip-changelog]

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,6 +27,9 @@ name = "Java"
 [[stacks]]
 id = "heroku-18"
 
+[[stacks]]
+id = "heroku-20"
+
 # this is to allow testing of other stack compatibility and is not a guarantee
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
Adds support for the `heroku/heroku:20` stack to the CNB implementation of this buildpack.