### PR TITLE
Remove heroku-16 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ orbs:
   pack: buildpacks/pack@0.2.0
 
 executors:
-  heroku-16:
-    docker:
-      - image: heroku/heroku:16
   heroku-18:
     docker:
       - image: heroku/heroku:18
@@ -20,7 +17,7 @@ jobs:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-16", "heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20"]
     docker:
       - image: circleci/ruby:2.7
     environment:
@@ -92,7 +89,7 @@ jobs:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-16", "heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20"]
     environment:
       STACK: << parameters.heroku-stack >>
     executor:
@@ -105,7 +102,7 @@ jobs:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-16", "heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20"]
     environment:
       # The unit tests change behaviour to test CNB specifics if this env var is set.
       CNB_STACK_ID: << parameters.heroku-stack >>
@@ -141,7 +138,6 @@ jobs:
               -recreate "${CIRCLE_TAG}" "heroku-java-cnb-${CIRCLE_TAG}.tgz"
 
 workflows:
-  version: 2.1
   default-ci-workflow:
     jobs:
       - rapier
@@ -149,17 +145,17 @@ workflows:
       - unit-tests-heroku-buildpack:
           matrix:
             parameters:
-              heroku-stack: ["heroku-16", "heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20"]
 
       - unit-tests-cloud-native-buildpack:
           matrix:
             parameters:
-              heroku-stack: ["heroku-16", "heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20"]
 
       - hatchet:
           matrix:
             parameters:
-              heroku-stack: ["heroku-16", "heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20"]
 
   cnb-release-workflow:
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## main
 
++ Remove heroku-16 support
+
 ## v69
 
-* Upgrade CNB API compatibility version to 0.4
++ Upgrade CNB API compatibility version to 0.4
 
 ## v68
 


### PR DESCRIPTION
The Heroku-16 stack reached end of life on May 1st, 2021, and from June 1st, 2021, the ability to build will also be disabled. See: https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

As such after June 1st, Heroku-16 must be removed from the buildpack CI test matrix, so that CI on the repository continues to pass.

Closes [GUS-W-9329681](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000N0QcYAK/view)