### PR TITLE
Vendor buildpack-stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+* Vendor buildpack-stdlib rather than downloading it at build time
+
 ## v71
 
 + Add heroku-22 support

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ ENV_DIR=$3
 
 source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh
-source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
+source $BP_DIR/lib/buildpack-stdlib-v7.sh
 
 export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 

--- a/bin/test
+++ b/bin/test
@@ -10,7 +10,7 @@ ENV_DIR=$2
 
 source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh
-source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
+source $BP_DIR/lib/buildpack-stdlib-v7.sh
 
 export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -13,7 +13,7 @@ ENV_DIR=$3
 
 source $BP_DIR/lib/common.sh
 source $BP_DIR/lib/maven.sh
-source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
+source $BP_DIR/lib/buildpack-stdlib-v7.sh
 
 export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 

--- a/lib/buildpack-stdlib-v7.sh
+++ b/lib/buildpack-stdlib-v7.sh
@@ -1,0 +1,164 @@
+# Buildpack defaults
+# ---------------
+
+export BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}
+
+# Standard Output
+# ---------------
+
+# Buildpack Steps.
+puts_step() {
+  if [[ "$@" == "-" ]]; then
+    read output
+  else
+    output=$@
+  fi
+  echo -e "\e[1m\e[36m=== $output\e[0m"
+  unset output
+}
+
+# Buildpack Error.
+puts_error() {
+  if [[ "$@" == "-" ]]; then
+    read output
+  else
+    output=$@
+  fi
+  echo -e "\e[1m\e[31m=!= $output\e[0m"
+}
+
+# Buildpack Warning.
+puts_warn() {
+  if [[ "$@" == "-" ]]; then
+    read output
+  else
+    output=$@
+  fi
+  echo -e "\e[1m\e[33m=!= $output\e[0m"
+}
+
+
+# Buildpack Utilities
+# -------------------
+
+# Usage: $ set-env key value
+# NOTICE: Expects PROFILE_PATH & EXPORT_PATH to be set!
+set_env() {
+  # TODO: automatically create profile path directory if it doesn't exist.
+  echo "export $1=$2" >> $PROFILE_PATH
+  echo "export $1=$2" >> $EXPORT_PATH
+}
+
+# Usage: $ set-default-env key value
+# NOTICE: Expects PROFILE_PATH & EXPORT_PATH to be set!
+set_default_env() {
+  echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
+  echo "export $1=\${$1:-$2}" >> $EXPORT_PATH
+}
+
+# Usage: $ un-set-env key
+# NOTICE: Expects PROFILE_PATH to be set!
+un_set_env() {
+  echo "unset $1" >> $PROFILE_PATH
+}
+
+# Usage: $ _env-blacklist pattern
+# Outputs a regex of default blacklist env vars.
+_env_blacklist() {
+  local regex=${1:-''}
+  if [ -n "$regex" ]; then
+    regex="|$regex"
+  fi
+  echo "^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH$regex)$"
+}
+
+# Usage: $ export-env ENV_DIR WHITELIST BLACKLIST
+# Exports the environment variables defined in the given directory.
+export_env() {
+  local env_dir=${1:-$ENV_DIR}
+  local whitelist=${2:-''}
+  local blacklist="$(_env_blacklist $3)"
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$whitelist" | grep -qvE "$blacklist" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}
+
+# Usage: $ sub-env command
+# Runs a subshell of specified command with user-provided config.
+# NOTICE: Expects ENV_DIR to be set. WHITELIST & BLACKLIST are optional.
+# Examples:
+#    WHITELIST=${2:-''}
+#    BLACKLIST=${3:-'^(GIT_DIR|PYTHONHOME|LD_LIBRARY_PATH|LIBRARY_PATH|PATH)$'}
+sub_env() {
+  (
+    export_env $ENV_DIR $WHITELIST $BLACKLIST
+
+    $1
+  )
+}
+
+# Logging
+# -------
+
+# Notice: These functions expect BPLOG_PREFIX and BUILDPACK_LOG_FILE to be defined (BUILDPACK_LOG_FILE can point to /dev/null if not provided by the buildpack).
+# Example: BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}; BPLOG_PREFIX="buildpack.go"
+
+# Returns now, in milleseconds. Useful for logging.
+# Example: $ let start=$(nowms); sleep 30; mtime "glide.install.time" "${start}"
+nowms() {
+    date +%s%3N
+}
+
+# Log arbitrary data to the logfile (e.g. a packaging file).
+# Usage: $ bplog "$(<${vendorJSON})
+bplog() {
+  echo -n ${@} | awk 'BEGIN {printf "msg=\""; f="%s"} {gsub(/"/, "\\\"", $0); printf f, $0} {if (NR == 1) f="\\n%s" } END { print "\"" }' >> ${BUILDPACK_LOG_FILE}
+}
+
+# Measures time elapsed for a specific build step.
+# Usage: $ let start=$(nowms); mtime "glide.install.time" "${start}"
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#distributions-measure
+mtime() {
+    local key="${BPLOG_PREFIX}.${1}"
+    local start="${2}"
+    local end="${3:-$(nowms)}"
+    echo "${key} ${start} ${end}" | awk '{ printf "measure#%s=%.3f\n", $1, ($3 - $2)/1000 }' >> ${BUILDPACK_LOG_FILE}
+}
+
+# Logs a count for a specific built step.
+# Usage: $ mcount "tool.govendor"
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#counting-count
+mcount() {
+    local k="${BPLOG_PREFIX}.${1}"
+    local v="${2:-1}"
+    echo "count#${k}=${v}" >> ${BUILDPACK_LOG_FILE}
+}
+
+# Logs a measure for a specific build step.
+# Usage: $ mmeasure "tool.installed_dependencies" 42
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#distributions-measure
+mmeasure() {
+    local k="${BPLOG_PREFIX}.${1}"
+    local v="${2}"
+    echo "measure#${k}=${v}" >> ${BUILDPACK_LOG_FILE}
+}
+
+# Logs a unuique measurement build step.
+# Usage: $ munique "versions.count" 2.7.13
+# https://github.com/heroku/engineering-docs/blob/master/guides/logs-as-data.md#uniques-unique
+munique() {
+    local k="${BPLOG_PREFIX}.${1}"
+    local v="${2}"
+    echo "unique#${k}=${v}" >> ${BUILDPACK_LOG_FILE}
+}
+
+# Measures when an exit path to the buildpack is reached, given a name, then exits 1.
+# Usage: $ mcount-exi "binExists"
+mcount_exit() {
+    mcount "error.${1}"
+    exit 1
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 export DEFAULT_MAVEN_VERSION="3.6.2"
-export BUILDPACK_STDLIB_URL="https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh"
 
 install_maven() {
   local installDir=$1

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -33,7 +33,7 @@ testCompileWithoutSystemProperties() {
   assertCapturedSuccess
 
   _assertMavenLatest
-  assertCaptured "Installing JDK 1.8"
+  assertCaptured "Installing OpenJDK 1.8"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
   assertTrue "system.properties was not cached" "[ -f $CACHE_DIR/system.properties ]"

--- a/test/spec/db_spec.rb
+++ b/test/spec/db_spec.rb
@@ -9,7 +9,7 @@ describe "Heroku's Java buildpack" do
         end
 
         app.deploy do
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).to include("Installing Maven")
           expect(app.output).to include("BUILD SUCCESS")
           expect(http_get(app, :path => "db")).to match("Read from DB:")

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -10,7 +10,7 @@ describe "Heroku's Java buildpack" do
           end
 
           app.deploy do
-            expect(app.output).to include("Installing JDK #{openjdk_version}")
+            expect(app.output).to include("Installing OpenJDK #{openjdk_version}")
             expect(app.output).to include("BUILD SUCCESS")
             # Commit ed358d63b384bc7c8cf96be61ada768f4cc55a19 on the example app added Maven Wrapper to
             # the project, bypassing Maven installation entirely.
@@ -21,7 +21,7 @@ describe "Heroku's Java buildpack" do
             app.commit!
             app.push!
 
-            expect(app.output).to include("Installing JDK #{openjdk_version}")
+            expect(app.output).to include("Installing OpenJDK #{openjdk_version}")
             expect(app.output).to include("BUILD SUCCESS")
             expect(app.output).not_to include("BUILD FAILURE")
             expect(app.output).not_to include("Installing Maven")
@@ -37,7 +37,7 @@ describe "Heroku's Java buildpack" do
           end
 
           app.deploy do
-            expect(app.output).to include("Installing JDK #{openjdk_version}")
+            expect(app.output).to include("Installing OpenJDK #{openjdk_version}")
             expect(app.output).to include("BUILD SUCCESS")
             expect(app.output).not_to include("BUILD FAILURE")
             expect(http_get(app)).to eq("/1")
@@ -91,7 +91,7 @@ describe "Heroku's Java buildpack" do
           end
 
           app.deploy do
-            expect(app.output).to include("Installing JDK #{openjdk_version}")
+            expect(app.output).to include("Installing OpenJDK #{openjdk_version}")
             expect(app.output).to include("BUILD SUCCESS")
             expect(app.output).not_to include("BUILD FAILURE")
             expect(http_get(app)).to eq("All Good!!!")
@@ -107,7 +107,7 @@ describe "Heroku's Java buildpack" do
           end
 
           app.deploy do
-            expect(app.output).to include("Installing JDK #{openjdk_version}")
+            expect(app.output).to include("Installing OpenJDK #{openjdk_version}")
             expect(app.output).to include("BUILD SUCCESS")
             expect(app.output).not_to include("BUILD FAILURE")
 

--- a/test/spec/maven_spec.rb
+++ b/test/spec/maven_spec.rb
@@ -9,7 +9,7 @@ describe "Heroku's Java buildpack" do
         end
 
         app.deploy do
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).to include(".polyglot.pom.yaml")
           expect(app.output).not_to include("BUILD FAILURE")
           expect(app.output).to include("BUILD SUCCESS")

--- a/test/spec/spring_spec.rb
+++ b/test/spec/spring_spec.rb
@@ -10,7 +10,7 @@ describe "Heroku's Java buildpack" do
         end
 
         app.deploy do
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).to match(%r{Building war: /tmp/.*/target/spring-boot-example-1.0-SNAPSHOT.war})
           expect(app.output).not_to match(%r{Building jar: /tmp/.*/target/spring-boot-example-1.0-SNAPSHOT.jar})
           expect(app.output).not_to include("BUILD FAILURE")
@@ -27,7 +27,7 @@ describe "Heroku's Java buildpack" do
         end
 
         app.deploy do |app|
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).not_to include("Installing Maven")
           expect(app.output).not_to match(%r{Building war: /tmp/.*/target/spring-boot-example-1.0-SNAPSHOT.war})
           expect(app.output).to match(%r{Building jar: /tmp/.*/target/spring-boot-example-1.0-SNAPSHOT.jar})
@@ -46,7 +46,7 @@ describe "Heroku's Java buildpack" do
         end
 
         app.deploy do |app|
-          expect(app.output).to include("Installing JDK #{DEFAULT_OPENJDK_VERSION}")
+          expect(app.output).to include("Installing OpenJDK #{DEFAULT_OPENJDK_VERSION}")
           expect(app.output).not_to match(%r{Building war: /tmp/.*/target/spring-boot-example-1.0-SNAPSHOT.war})
           expect(app.output).to match(%r{Building jar: /tmp/.*/target/spring-boot-example-1.0-SNAPSHOT.jar})
           expect(app.output).not_to include("BUILD FAILURE")


### PR DESCRIPTION
Since:
- The buildpack-stdlib repo has been sunset/archived, so no future changes to it are expected.
- It's a script rather than a binary and is a small file, so a great candidate for vendoring.
- Downloading it at runtime causes more potential failures modes, as seen in https://github.com/heroku/heroku-buildpack-clojure/pull/118

GUS-W-11283397.