### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 * Vendor buildpack-stdlib rather than downloading it at build time
+* Switch to the recommended regional S3 domain instead of the global one
 
 ## v71
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -13,7 +13,7 @@ install_maven() {
   mcount "mvn.version.${mavenVersion}"
 
   status_pending "Installing Maven ${mavenVersion}"
-  local mavenUrl="https://lang-jvm.s3.amazonaws.com/maven-${mavenVersion}.tar.gz"
+  local mavenUrl="https://lang-jvm.s3.us-east-1.amazonaws.com/maven-${mavenVersion}.tar.gz"
   if is_supported_maven_version "${mavenVersion}" "${mavenUrl}"; then
     download_maven "${mavenUrl}" "${installDir}" "${mavenHome}"
     status_done
@@ -87,7 +87,7 @@ install_jdk() {
   local cache_dir=${2}
 
   let start=$(nowms)
-  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz}
+  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
   curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
   source /tmp/jvm-common/bin/util

--- a/test/common_test.sh
+++ b/test/common_test.sh
@@ -72,17 +72,17 @@ test_detect_maven_version_with_no_file() {
 }
 
 test_is_supported_maven_version_default() {
-  capture is_supported_maven_version "$DEFAULT_MAVEN_VERSION" "https://lang-jvm.s3.amazonaws.com/maven-$DEFAULT_MAVEN_VERSION.tar.gz"
+  capture is_supported_maven_version "$DEFAULT_MAVEN_VERSION" "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-$DEFAULT_MAVEN_VERSION.tar.gz"
   assertCapturedSuccess
 }
 
 test_is_supported_maven_version_old() {
-  capture is_supported_maven_version "3.6.2" "https://lang-jvm.s3.amazonaws.com/maven-3.6.2.tar.gz"
+  capture is_supported_maven_version "3.6.2" "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.6.2.tar.gz"
   assertCapturedSuccess
 }
 
 test_is_supported_maven_version_no() {
-  capture is_supported_maven_version "1.1.1" "https://lang-jvm.s3.amazonaws.com/maven-1.1.1.tar.gz"
+  capture is_supported_maven_version "1.1.1" "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-1.1.1.tar.gz"
   assertEquals 1 "${RETURN}"
 }
 


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.