### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             sudo apt-get install file
       - run:
           name: Download and unpack shunit 2.1.6
-          command: curl -sSf https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
+          command: curl -sSf --fail --retry 3 --retry-connrefused --connect-timeout 5 https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
       - run:
           name: Clone heroku-buildpack-testrunner
           command: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+* Adjust curl retry and connection timeout handling
 * Vendor buildpack-stdlib rather than downloading it at build time
 * Switch to the recommended regional S3 domain instead of the global one
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -29,7 +29,7 @@ download_maven() {
   local installDir=$2
   local mavenHome=$3
   rm -rf $mavenHome
-  curl --retry 3 --silent --max-time 60 --location "${mavenUrl}" | tar xzm -C $installDir
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --max-time 60 --location "${mavenUrl}" | tar xzm -C $installDir
   chmod +x $mavenHome/bin/mvn
 }
 
@@ -38,7 +38,7 @@ is_supported_maven_version() {
   local mavenUrl=${2:?}
   if [ "$mavenVersion" = "$DEFAULT_MAVEN_VERSION" ]; then
     return 0
-  elif curl -I --retry 3 --fail --silent --max-time 5 --location "${mavenUrl}" > /dev/null; then
+  elif curl -I --retry 3 --retry-connrefused --connect-timeout 5 --fail --silent --max-time 5 --location "${mavenUrl}" > /dev/null; then
     return 0
   else
     return 1
@@ -89,7 +89,7 @@ install_jdk() {
   let start=$(nowms)
   JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
-  curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
   source /tmp/jvm-common/bin/util
   source /tmp/jvm-common/bin/java
   source /tmp/jvm-common/opt/jdbc.sh

--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -38,7 +38,7 @@ _mvn_settings_opt() {
   elif [ -n "$MAVEN_SETTINGS_URL" ]; then
     local settingsXml="${mavenInstallDir}/.m2/settings.xml"
     mkdir -p $(dirname ${settingsXml})
-    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output ${settingsXml}
+    curl --retry 3 --retry-connrefused --connect-timeout 5 --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output ${settingsXml}
     mcount "mvn.settings.url"
     if [ -f ${settingsXml} ]; then
       echo -n "-s ${settingsXml}"

--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -38,7 +38,7 @@ _mvn_settings_opt() {
   elif [ -n "$MAVEN_SETTINGS_URL" ]; then
     local settingsXml="${mavenInstallDir}/.m2/settings.xml"
     mkdir -p $(dirname ${settingsXml})
-    curl --retry 3 --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output ${settingsXml}
+    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output ${settingsXml}
     mcount "mvn.settings.url"
     if [ -f ${settingsXml} ]; then
       echo -n "-s ${settingsXml}"

--- a/test/spec/agent_spec.rb
+++ b/test/spec/agent_spec.rb
@@ -8,7 +8,7 @@ describe "Heroku's Java buildpack" do
           set_java_version(DEFAULT_OPENJDK_VERSION)
 
           java_agent_filename="heroku-javaagent-2.0.jar"
-          run("curl --silent -O -L https://repo1.maven.org/maven2/com/heroku/agent/heroku-javaagent/2.0/#{java_agent_filename}")
+          run("curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent -O -L https://repo1.maven.org/maven2/com/heroku/agent/heroku-javaagent/2.0/#{java_agent_filename}")
           write_to_procfile("web: java $JAVA_OPTS -javaagent:#{java_agent_filename}=stdout=true,lxmem=true -jar target/dependency/webapp-runner.jar --port $PORT target/*.war")
         end
 


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.