### PR TITLE
Reduce Dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "skip changelog"


### PR DESCRIPTION
To reduce the churn + email notification noise slightly. GitHub will still open PRs for any security issues outside of the monthly cadence.