### PR TITLE
Group minor/patch version Ruby Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,18 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+      - "ruby"
       - "skip changelog"
+    groups:
+      ruby-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     labels:
       - "dependencies"
+      - "github actions"
       - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,10 +9,8 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-22.04
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ruby minor/patch dependencies will now be grouped, using the new Dependabot grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

This hasn't been enabled for the GitHub Actions dependencies, since they all use major pinning (since we only use the official actions like `actions/checkout`).

In addition, the check changelog skipping strategy has been updated to use the `skip changelog` label for (a) explicitness, (b) to allow removing the label in situations where we realise a changelog entry is required, (c) for consistency with other repos.

GUS-W-14303554.