### PR TITLE
Add Micronaut and Quarkus support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add default process type for Micronaut and Quarkus. ([#224](https://github.com/heroku/heroku-buildpack-java/pull/224))
 
 ## [v73] - 2023-08-14
 

--- a/bin/release
+++ b/bin/release
@@ -16,15 +16,23 @@ EOF
 fi
 
 if [ ! -f $BUILD_DIR/Procfile ] && [ -d $BUILD_DIR/target ]; then
-  cd $BUILD_DIR
-  for jarFile in $(find target -maxdepth 1 -name "*.jar" -type f); do
-    if is_spring_boot $BUILD_DIR; then
-      echo "default_process_types:"
-      echo "  web: java -Dserver.port=\$PORT \$JAVA_OPTS -jar $jarFile"
-    elif is_wildfly_swarm $BUILD_DIR; then
-      echo "default_process_types:"
-      echo "  web: java -Dswarm.http.port=\$PORT \$JAVA_OPTS -jar $jarFile"
-    fi
-    break;
-  done
+  if is_quarkus $BUILD_DIR; then
+    echo "default_process_types:"
+    echo "  web: java -Dquarkus.http.port=\$PORT \$JAVA_OPTS -jar target/quarkus-app/quarkus-run.jar"
+  else
+    cd $BUILD_DIR
+      for jarFile in $(find target -maxdepth 1 -name "*.jar" -type f -exec ls -S {} +); do
+        if is_spring_boot $BUILD_DIR; then
+          echo "default_process_types:"
+          echo "  web: java -Dserver.port=\$PORT \$JAVA_OPTS -jar $jarFile"
+        elif is_wildfly_swarm $BUILD_DIR; then
+          echo "default_process_types:"
+          echo "  web: java -Dswarm.http.port=\$PORT \$JAVA_OPTS -jar $jarFile"
+        elif is_micronaut $BUILD_DIR; then
+          echo "default_process_types:"
+          echo "  web: java -Dmicronaut.server.port=\$PORT \$JAVA_OPTS -jar $jarFile"
+        fi
+        break;
+      done
+  fi
 fi

--- a/lib/frameworks.sh
+++ b/lib/frameworks.sh
@@ -13,6 +13,18 @@ is_wildfly_swarm() {
     test -n "$(grep "<groupId>org.wildfly.swarm" ${buildDir}/pom.xml)"
 }
 
+is_micronaut() {
+  local buildDir=${1:?}
+  test -f ${buildDir}/pom.xml &&
+    test -n "$(grep "<groupId>io.micronaut" ${buildDir}/pom.xml)"
+}
+
+is_quarkus() {
+  local buildDir=${1:?}
+  test -f ${buildDir}/pom.xml &&
+    test -n "$(grep "<groupId>io.quarkus" ${buildDir}/pom.xml)"
+}
+
 has_postgres() {
   local buildDir=${1:?}
   test -f ${buildDir}/pom.xml && (


### PR DESCRIPTION
QOL improvement for when users initially set up a Quarkus or Micronaut app. It picks the correct build task and sets a default web process type if no `Procfile` is present. This is the same mechanism we use for the other frameworks.