### PR TITLE
Remove support for heroku-20 stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-20", "heroku-22", "heroku-24"]
+        stack: ["heroku-22", "heroku-24"]
     env:
       HATCHET_APP_LIMIT: 100
       PARALLEL_SPLIT_TEST_PROCESSES: 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Remove heroku-20 support ([#245](https://github.com/heroku/heroku-buildpack-java/pull/245))
 
 ## [v75] - 2025-02-24
 


### PR DESCRIPTION
Since the Heroku-20 stack has reached end-of-life, and as such builds using it are no longer supported by the Heroku build system: https://devcenter.heroku.com/changelog-items/3230

This fixes the integration tests failing in CI for the Heroku-20 stack, due to the build system now (as expected) rejecting the jobs.

Any non-Heroku consumers of this buildpack that wish to continue using the Heroku-20 stack should pin to the previous version of this buildpack.