### PR TITLE
Validate Maven Wrapper installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add Maven Wrapper validation with clear error message when required files are missing ([#000](https://github.com/heroku/heroku-buildpack-java/pull/000))
 
 ## [v78] - 2025-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Add Maven Wrapper validation with clear error message when required files are missing ([#000](https://github.com/heroku/heroku-buildpack-java/pull/000))
+* Add Maven Wrapper validation with clear error message when required files are missing ([#266](https://github.com/heroku/heroku-buildpack-java/pull/266))
 
 ## [v78] - 2025-09-04
 

--- a/test/spec/misc_spec.rb
+++ b/test/spec/misc_spec.rb
@@ -106,20 +106,20 @@ RSpec.describe 'Maven buildpack' do
 
     app.deploy do
       expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
-        remote:  !     Error: Maven Wrapper files are missing or incomplete.
+        remote:  !     Error: Maven Wrapper files are missing or incomplete\\.
         remote:  !     
         remote:  !     The following required Maven Wrapper files were not found:
-        remote:  !       - .mvn/wrapper/maven-wrapper.properties
-        remote: 
+        remote:  !       - \\.mvn/wrapper/maven-wrapper\\.properties
+        remote:  !     
         remote:  !     To fix this issue, run this command in your project directory
         remote:  !     locally and commit the generated files:
         remote:  !     \\$ mvn wrapper:wrapper
         remote:  !     
         remote:  !     For more information about Maven Wrapper, see:
-        remote:  !     https://maven.apache.org/tools/wrapper/
-        remote:  !     https://devcenter.heroku.com/articles/java-support#specifying-a-maven-version
+        remote:  !     https://maven\\.apache\\.org/tools/wrapper/
+        remote:  !     https://devcenter\\.heroku\\.com/articles/java-support#specifying-a-maven-version
         remote: 
-        remote:  !     Push rejected, failed to compile Java app.
+        remote:  !     Push rejected, failed to compile Java app\\.
       REGEX
     end
   end

--- a/test/spec/misc_spec.rb
+++ b/test/spec/misc_spec.rb
@@ -96,4 +96,31 @@ RSpec.describe 'Maven buildpack' do
       REGEX
     end
   end
+
+  it 'fails with descriptive error when Maven Wrapper properties file is missing' do
+    app = Hatchet::Runner.new('simple-http-service', allow_failure: true)
+
+    app.before_deploy do
+      `rm .mvn/wrapper/maven-wrapper.properties`
+    end
+
+    app.deploy do
+      expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+        remote:  !     Error: Maven Wrapper files are missing or incomplete.
+        remote:  !     
+        remote:  !     The following required Maven Wrapper files were not found:
+        remote:  !       - .mvn/wrapper/maven-wrapper.properties
+        remote: 
+        remote:  !     To fix this issue, run this command in your project directory
+        remote:  !     locally and commit the generated files:
+        remote:  !     \\$ mvn wrapper:wrapper
+        remote:  !     
+        remote:  !     For more information about Maven Wrapper, see:
+        remote:  !     https://maven.apache.org/tools/wrapper/
+        remote:  !     https://devcenter.heroku.com/articles/java-support#specifying-a-maven-version
+        remote: 
+        remote:  !     Push rejected, failed to compile Java app.
+      REGEX
+    end
+  end
 end


### PR DESCRIPTION
Before #257, invalid Maven wrapper installations were silently ignored. The refactor removed that logic to make issues apparent should they still exist. As it turns out a much larger percentage of applications have broken Maven wrapper installations than expected. To aid these users with fixing their Maven Wrapper installation, this PR add explicit validation again and provides a clear error message when a broken installation was detected.

## Changelog

* Add Maven Wrapper validation with clear error message when required files are missing

GUS-W-19546430