### PR TITLE
Change Maven Wrapper validation from error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Change Maven Wrapper validation from build-failing error to warning when properties file is missing ([#000](https://github.com/heroku/heroku-buildpack-java/pull/000))
+* Change Maven Wrapper validation from build-failing error to warning when properties file is missing ([#268](https://github.com/heroku/heroku-buildpack-java/pull/268))
 
 ## [v79] - 2025-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Change Maven Wrapper validation from build-failing error to warning when properties file is missing ([#000](https://github.com/heroku/heroku-buildpack-java/pull/000))
 
 ## [v79] - 2025-09-04
 

--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -231,7 +231,10 @@ function maven::install_maven() {
 function maven::should_use_wrapper() {
 	local build_dir="${1}"
 
-	[[ -f "${build_dir}/mvnw" ]] && [[ -z "$(java_properties::get "${build_dir}/system.properties" "maven.version")" ]]
+	# A surprising number of projects don't have a maven-wrapper.properties file,
+	# but have an mvnw script. We will enforce correct Maven wrapper setup at some point, but
+	# for now, we continue to support this and fall back to not using the wrapper in such cases.
+	[[ -f "${build_dir}/mvnw" ]] && [[ -f "${build_dir}/.mvn/wrapper/maven-wrapper.properties" ]] && [[ -z "$(java_properties::get "${build_dir}/system.properties" "maven.version")" ]]
 }
 
 # Ensures all required Maven Wrapper files are present in the build directory.

--- a/test/spec/misc_spec.rb
+++ b/test/spec/misc_spec.rb
@@ -97,29 +97,35 @@ RSpec.describe 'Maven buildpack' do
     end
   end
 
-  it 'fails with descriptive error when Maven Wrapper properties file is missing' do
-    app = Hatchet::Runner.new('simple-http-service', allow_failure: true)
+  it 'warns when Maven Wrapper properties file is missing but continues build' do
+    app = Hatchet::Runner.new('simple-http-service')
 
     app.before_deploy do
       `rm .mvn/wrapper/maven-wrapper.properties`
     end
 
     app.deploy do
+      expect(app.output).to include('[INFO] BUILD SUCCESS')
       expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
-        remote:  !     Error: Maven Wrapper files are missing or incomplete\\.
+        remote:  !     Warning: Maven Wrapper script found without properties file\\.
         remote:  !     
-        remote:  !     The following required Maven Wrapper files were not found:
-        remote:  !       - \\.mvn/wrapper/maven-wrapper\\.properties
+        remote:  !     Found mvnw script but missing \\.mvn/wrapper/maven-wrapper\\.properties\\.
+        remote:  !     The Maven Wrapper requires both files to function properly\\.
         remote:  !     
         remote:  !     To fix this issue, run this command in your project directory
         remote:  !     locally and commit the generated files:
         remote:  !     \\$ mvn wrapper:wrapper
         remote:  !     
+        remote:  !     Alternatively, if you don't want to use Maven Wrapper, you can
+        remote:  !     delete the mvnw file from your project, though the usage of the
+        remote:  !     Maven Wrapper is strongly recommended\\.
+        remote:  !     
+        remote:  !     IMPORTANT: This warning will become an error in a future version
+        remote:  !     of this buildpack\\. Please fix this issue as soon as possible\\.
+        remote:  !     
         remote:  !     For more information about Maven Wrapper, see:
         remote:  !     https://maven\\.apache\\.org/tools/wrapper/
         remote:  !     https://devcenter\\.heroku\\.com/articles/java-support#specifying-a-maven-version
-        remote: 
-        remote:  !     Push rejected, failed to compile Java app\\.
       REGEX
     end
   end


### PR DESCRIPTION
Changes incomplete Maven Wrapper setup from a build-failing error to a warning when the maven-wrapper.properties file is missing but the mvnw script exists. Maven builds now continue instead of failing when properties file is missing by using the Heroku Maven default version. This is consistent with buildpack behaviour before the latest refactoring work.

The error message as been reworded to be a warning with additional information how and when to fix this issue. This warning will become an error eventually.

GUS-W-19581154