### PR TITLE
Strip literal '^[' ANSI escapes in test output cleaning

### DIFF
--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -57,7 +57,10 @@ def clean_output(output)
     # https://github.com/heroku/hatchet/issues/162
     .gsub(/ {8}(?=\R)/, '')
     # Remove ANSI colour codes used in buildpack output (e.g. error messages).
-    .gsub(/\e\[[0-9;]+m/, '')
+    # Some environments (notably GitHub Actions runners) deliver these with the
+    # escape byte rendered as the two-character literal "^[" instead of 0x1B,
+    # so strip both variants.
+    .gsub(/(?:\e|\^\[)\[[0-9;]+m/, '')
     # Remove trailing space from empty "remote: " lines added by Heroku
     .gsub(/^remote: $/, 'remote:')
 end


### PR DESCRIPTION
Heroku's build platform emits ANSI colour codes on error/warning banners. Locally these arrive as the ESC control byte (`0x1B`), but on GitHub Actions runners some of them arrive as the two literal characters `^` + `[`. The existing `clean_output` regex only matched real ESC, so on CI those escape sequences slipped through and broke `include?` assertions against the cleaned output.

GUS-W-24055964